### PR TITLE
android visible group, android added e-mails, global module fixes, getPage implementation, permission request fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - NDK_VERSION=r10e
-    - FUSE_VERSION=0.21.0.6650
+    - FUSE_VERSION=0.25.5.7677
     - UNOPROJ=contacts_example
     - NAME=ContactsExample
 language: 

--- a/Contacts.uno
+++ b/Contacts.uno
@@ -1,13 +1,22 @@
 using Uno;
+using Uno.UX;
 using Uno.Threading;
+using Fuse;
 using Fuse.Scripting;
 using Fuse.Reactive;
 using Bolav.ForeignHelpers;
 
+[UXGlobalModule]
 public class Contacts : NativeModule {
+
+	static readonly Contacts _instance;
 
 	public Contacts()
 	{
+		if (_instance != null) return;
+		_instance = this;
+		Resource.SetGlobalKey(_instance, "Contacts");
+		
 		AddMember(new NativePromise<string, string>("authorize", Authorize, null));
 		AddMember(new NativeFunction("getAll", (NativeCallback)GetAll));
 	}

--- a/Contacts.uno
+++ b/Contacts.uno
@@ -28,6 +28,13 @@ public class Contacts : NativeModule {
 		return a.GetScriptingArray();
 	}
 
+	object GetPage (Context c, object[] args)
+	{
+		var a = new JSList(c);
+		ContactsImpl.GetPageImpl(a, Marshal.ToInt(args[0]), Marshal.ToInt(args[1]));
+		return a.GetScriptingArray();
+	}
+
 	Future<string> Authorize (object[] args)
 	{
 		return ContactsImpl.AuthorizeImpl();

--- a/ContactsImpl.Android.uno
+++ b/ContactsImpl.Android.uno
@@ -35,6 +35,7 @@ public extern(Android) class ContactsImpl
 		    	@{ForeignDict:Of(row).SetKeyVal(string,string):Call("name",
 		    		cur.getString(cur.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME)) )};
 
+		    	// read the phone numbers at the current cursor
 		        if (Integer.parseInt(cur.getString(cur.getColumnIndex(
 		                    ContactsContract.Contacts.HAS_PHONE_NUMBER))) > 0) {
 		            Cursor pCur = cr.query(
@@ -53,6 +54,21 @@ public extern(Android) class ContactsImpl
 		            }
 		            pCur.close();
 		        }
+
+		    	// read the e-mail addresses at the current cursor
+				Cursor emailCur = cr.query( 
+			 				ContactsContract.CommonDataKinds.Email.CONTENT_URI, 
+			 				null,
+			 				ContactsContract.CommonDataKinds.Email.CONTACT_ID + " = ?", 
+			 				new String[]{id}, null);
+				Object emailList = @{ForeignDict:Of(row).AddListForKey(string):Call("email")};
+		 		while (emailCur.moveToNext()) { 
+	            	Object emailRow = @{ForeignList:Of(emailList).NewDictRow():Call()};
+	            	@{ForeignDict:Of(emailRow).SetKeyVal(string,string):Call("email", 
+	            		emailCur.getString(emailCur.getColumnIndex(ContactsContract.CommonDataKinds.Email.DATA))
+	            		)};
+		 		} 
+		 		emailCur.close();
 		    }
 		}
 		cur.close();

--- a/ContactsImpl.Android.uno
+++ b/ContactsImpl.Android.uno
@@ -74,6 +74,64 @@ public extern(Android) class ContactsImpl
 		cur.close();
 	@}
 
+	[Foreign(Language.Java)]
+	public static void GetPageImpl(ForeignList ret, int numRows, int curPage) 
+	@{
+		Activity a = com.fuse.Activity.getRootActivity();
+		ContentResolver cr = a.getContentResolver();
+		String selection =  ContactsContract.Contacts.IN_VISIBLE_GROUP + " = ?";
+		String[] Args = { "1" };
+		String limiter = "display_name COLLATE LOCALIZED LIMIT " + numRows + " OFFSET " + (numRows * curPage);
+		Cursor cur = cr.query(ContactsContract.Contacts.CONTENT_URI,
+		        null, selection, Args, limiter);
+		
+		// DatabaseUtils.dumpCursor(cur);
+
+		if (cur != null) {
+			if (cur.getCount() > 0) {
+			    while (cur.moveToNext()) {
+			    	Object row = @{ForeignList:Of(ret).NewDictRow():Call()};
+
+			    	String id = cur.getString(cur.getColumnIndex(ContactsContract.Contacts._ID));
+			    	// @{ForeignDict:Of(row).SetKeyVal(string,string):Call("id", id)};
+			    	@{ForeignDict:Of(row).SetKeyVal(string,string):Call("name",cur.getString(cur.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME)) )};
+
+			        if (Integer.parseInt(cur.getString(cur.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER))) > 0) {
+			            Cursor pCur = cr.query(
+			                    ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+			                    null,
+			                    ContactsContract.CommonDataKinds.Phone.CONTACT_ID +" = ?",
+			                    new String[]{id}, null);
+
+			            Object phoneList = @{ForeignDict:Of(row).AddListForKey(string):Call("phone")};
+			            while (pCur.moveToNext()) {
+			            	Object phoneRow = @{ForeignList:Of(phoneList).NewDictRow():Call()};
+			            	@{ForeignDict:Of(phoneRow).SetKeyVal(string,string):Call("phone", 
+			            		pCur.getString(pCur.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER))
+			            		)};
+			            }
+			            pCur.close();
+			        }
+
+					Cursor emailCur = cr.query( 
+				 				ContactsContract.CommonDataKinds.Email.CONTENT_URI, 
+				 				null,
+				 				ContactsContract.CommonDataKinds.Email.CONTACT_ID + " = ?", 
+				 				new String[]{id}, null);
+					Object emailList = @{ForeignDict:Of(row).AddListForKey(string):Call("email")};
+			 		while (emailCur.moveToNext()) { 
+		            	Object emailRow = @{ForeignList:Of(emailList).NewDictRow():Call()};
+		            	@{ForeignDict:Of(emailRow).SetKeyVal(string,string):Call("email", 
+		            		emailCur.getString(emailCur.getColumnIndex(ContactsContract.CommonDataKinds.Email.DATA))
+		            		)};
+			 		} 
+			 		emailCur.close();
+			    }
+			}
+		}
+		cur.close();
+	@}
+
 	public static Future<string> AuthorizeImpl()
 	{
 		var p = new Promise<string>();

--- a/ContactsImpl.Android.uno
+++ b/ContactsImpl.Android.uno
@@ -19,8 +19,10 @@ public extern(Android) class ContactsImpl
 	@{
 		Activity a = com.fuse.Activity.getRootActivity();
 		ContentResolver cr = a.getContentResolver();
+		String selection =  ContactsContract.Contacts.IN_VISIBLE_GROUP + " = ?";
+		String[] Args = { "1" };
 		Cursor cur = cr.query(ContactsContract.Contacts.CONTENT_URI,
-		        null, null, null, null);
+		        null, selection, Args, null);
 
 		if (cur.getCount() > 0) {
 		    while (cur.moveToNext()) {

--- a/ContactsImpl.iOS.uno
+++ b/ContactsImpl.iOS.uno
@@ -92,7 +92,6 @@ public extern(iOS) class ContactsImpl
 		}
 		CFRelease(allPeople);
 	@} 
-}
 
 	[Foreign(Language.ObjC)]
 	public static void GetPageImpl(ForeignList ret, int numRows, int curPage) 

--- a/ContactsImpl.uno
+++ b/ContactsImpl.uno
@@ -10,6 +10,10 @@ public extern(!Mobile) class ContactsImpl
 		debug_log("Contacts only working on mobile");
 	} 
 
+	public static void GetPageImpl(JSList ret, int numRows, int curPage) {
+		debug_log("Contacts only working on mobile");
+	} 
+
 	public static Future<string> AuthorizeImpl()
 	{
 		var p = new Promise<string>();

--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ Returns an array of hashes of contacts
 ```
 console.log(JSON.stringify(contacts.getAll()));
 ```
+
+### getPage
+
+Returns an array of hashes of contacts, split by pages
+
+```
+readInLoop(0); // call the function, starting with page 0
+
+function readInLoop(page) {
+    var numEntries = 30; // number of entries per page
+	var proceed = true; // boolean to track state of recursion
+	var contactsPageList = contacts.getPage(numEntries, page); // retrieves the numEntries contacts objects, offset by (page * numEntries)
+	if (contactsPageList.length < numEntries) proceed = false; // if the current page returned less results than numEntries, we have reached the end of all contacts
+	// ... do something with contactsPageList here!
+	if (proceed) readInLoop(page+1); // call ourselves recursively with next page
+}
+```

--- a/contacts_example.unoproj
+++ b/contacts_example.unoproj
@@ -4,7 +4,8 @@
   "Packages": [
     "Fuse",
     "FuseJS",
-    "Android"
+    "Android",
+    "Uno.Permissions"
   ],
   "Includes": [
     "*"

--- a/contacts_include.unoproj
+++ b/contacts_include.unoproj
@@ -2,7 +2,8 @@
   "RootNamespace": "",
   "Packages": [
     "Fuse",
-    "FuseJS"
+    "FuseJS",
+    "Uno.Permissions"
   ],
   "Includes": [
     "./*.uno"


### PR DESCRIPTION
Here, I made the Android implementation pass extra params to cursor query, so that only those contact entries in visible group would get returned.
Without this, it returns all possible entries from connected google and other accounts set up on device, including all and any targets ever contacted by the owner.

The previous behaviour leads to crashes because of memory consumption and a number of weird-looking contacts entries with missing DISPLAY_NAME. The new approach only shows those entries a user would expect to have returned in most, if not all, cases - those specifically added in address book.

In addition to the above, I also made the Android implementation to read and return the e-mail addresses of contacts entries. As a result, items added to the Address book without phone numbers will also make it to the result set.
