### PR TITLE
Use latest Fuse-installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,8 @@ sudo: required
 
 cache:
   directories:
-#    - /Applications/Fuse.app
 #    - /usr/local/share/uno
-#    - $HOME/.fuse
     - $HOME/Library/Android
-#    - $HOME/fuse
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
   global:
     - NDK_VERSION=r10e
-    - FUSE_VERSION=0.25.5.7677
     - UNOPROJ=contacts_example
     - NAME=ContactsExample
 language: 

--- a/.travis/install-fuse.sh
+++ b/.travis/install-fuse.sh
@@ -8,19 +8,9 @@
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 	# In /Users/travis/build/bolav/fuse-travis
 	echo "Installing Fuse version ${FUSE_VERSION}"
-	ls -l /Applications/Fuse.app/Contents/Uno/uno.exe
-	echo "fuse/sdk"
-	cat ~/.fuse/sdkConfig.json
-	if [ -x /Applications/Fuse.app/Contents/Uno/uno.exe ]; then
-		echo "Existing installation"
-		cat  ~/.fuse/fuse_version
-		sudo cp ./.travis/files/uno /usr/local/bin/uno
-		exit 0
-	fi
 	wget https://api.fusetools.com/fuse-release-management/releases/${FUSE_VERSION}/osx
 	mv osx fuse_osx_${FUSE_VERSION}.pkg
 	sudo installer -pkg fuse_osx_${FUSE_VERSION}.pkg -target /
 	echo "Installed Fuse ${FUSE_VERSION}"
 	mkdir -p $HOME/.fuse
-	echo ${FUSE_VERSION} > $HOME/.fuse/fuse_version
 fi

--- a/.travis/install-fuse.sh
+++ b/.travis/install-fuse.sh
@@ -7,10 +7,10 @@
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 	# In /Users/travis/build/bolav/fuse-travis
-	echo "Installing Fuse version ${FUSE_VERSION}"
-	wget https://api.fusetools.com/fuse-release-management/releases/${FUSE_VERSION}/osx
-	mv osx fuse_osx_${FUSE_VERSION}.pkg
-	sudo installer -pkg fuse_osx_${FUSE_VERSION}.pkg -target /
-	echo "Installed Fuse ${FUSE_VERSION}"
+	echo "Installing latest Fuse beta version"
+	wget https://www.fusetools.com/downloads/latest/beta/osx -O fuse_osx.pkg
+	sudo installer -pkg fuse_osx.pkg -target /
+	echo "Installed Fuse"
+	fuse --version
 	mkdir -p $HOME/.fuse
 fi


### PR DESCRIPTION
This pull-request prevents having to bump the fuse-version for each release, and instead builds with the latest version ever time.

Unfortunately, this approach is incompatible with caching, because the fuse-version isn't know until the installer is finished. So the first step is to remove the caching of the fuse-installer.
